### PR TITLE
Add responsive grid layout

### DIFF
--- a/src/app/pages/create-user/create-user.component.html
+++ b/src/app/pages/create-user/create-user.component.html
@@ -1,6 +1,8 @@
-<div class="container mt-5">
-  <div class="card p-4 bg-light shadow">
-    <h2 class="text-center mb-4 text-rosado">Crear Nuevo Usuario</h2>
+<div class="container py-5">
+  <div class="row justify-content-center">
+    <div class="col-12 col-md-8 col-lg-6">
+      <div class="card p-4 bg-light shadow">
+        <h2 class="text-center mb-4 text-rosado">Crear Nuevo Usuario</h2>
 
     <form [formGroup]="form" (ngSubmit)="crearUsuario()" novalidate>
       <div class="mb-3">
@@ -52,5 +54,7 @@
       <button type="submit" class="btn btn-rosado w-100" [disabled]="form.invalid">Guardar Usuario</button>
       <div class="alert alert-danger mt-3" *ngIf="error">{{ error }}</div>
     </form>
+      </div>
+    </div>
   </div>
 </div>

--- a/src/app/pages/home/home.component.css
+++ b/src/app/pages/home/home.component.css
@@ -1,11 +1,26 @@
 
 .hero {
   background: url('/assets/img/hero-bg.jpg') center/cover no-repeat;
-  height: 70vh;
+  height: 80vh;
 }
 
-@media (max-width: 768px) {
+/* Pantallas pequeñas */
+@media (max-width: 575.98px) {
   .hero {
-    height: 50vh;
+    height: 40vh;
+  }
+}
+
+/* Pantallas medianas */
+@media (min-width: 576px) and (max-width: 991.98px) {
+  .hero {
+    height: 60vh;
+  }
+}
+
+/* Pantallas grandes */
+@media (min-width: 992px) {
+  .hero {
+    height: 80vh;
   }
 }

--- a/src/app/pages/login/login.component.css
+++ b/src/app/pages/login/login.component.css
@@ -9,12 +9,17 @@
 }
 
 .login-container {
-  max-width: 400px;
-  margin: 40px auto;
+  width: 100%;
   padding: 30px;
   background-color: #fff0f5;
   border-radius: 15px;
   box-shadow: 0 0 10px rgba(255, 105, 180, 0.2);
+}
+
+@media (max-width: 575.98px) {
+  .login-container {
+    padding: 20px;
+  }
 }
 
 h2 {

--- a/src/app/pages/login/login.component.html
+++ b/src/app/pages/login/login.component.html
@@ -1,5 +1,7 @@
-<div class="login-container">
-  <h2 class="text-center">Iniciar Sesión</h2>
+<div class="container py-5">
+  <div class="row justify-content-center">
+    <div class="col-12 col-md-8 col-lg-4 login-container">
+      <h2 class="text-center">Iniciar Sesión</h2>
 
   <form [formGroup]="loginForm" (ngSubmit)="iniciarSesion()" class="login-form">
     <div class="form-group mb-3">
@@ -43,4 +45,6 @@
 
     <div class="alert alert-danger mt-3" *ngIf="error">{{ error }}</div>
   </form>
+    </div>
+  </div>
 </div>

--- a/src/app/pages/recuperar/recuperar.component.css
+++ b/src/app/pages/recuperar/recuperar.component.css
@@ -1,10 +1,15 @@
 .recuperar-container {
-  max-width: 400px;
-  margin: 2rem auto;
+  width: 100%;
   padding: 1.5rem;
   background: #fff;
   border: 1px solid #ccc;
   border-radius: 6px;
+}
+
+@media (max-width: 575.98px) {
+  .recuperar-container {
+    padding: 1rem;
+  }
 }
 .form-group {
   margin-bottom: 1rem;

--- a/src/app/pages/recuperar/recuperar.component.html
+++ b/src/app/pages/recuperar/recuperar.component.html
@@ -1,5 +1,7 @@
-<div class="recuperar-container">
-  <h2>Recuperar Contraseña</h2>
+<div class="container py-5">
+  <div class="row justify-content-center">
+    <div class="col-12 col-md-8 col-lg-4 recuperar-container">
+      <h2>Recuperar Contraseña</h2>
 
   <form [formGroup]="recuperarForm" (ngSubmit)="onSubmit()" novalidate>
     <div class="form-group mb-3">
@@ -35,4 +37,6 @@
     ¡Revisa tu correo para recuperar tu contraseña!
   </div>
   <div class="alert alert-danger mt-3" *ngIf="error">{{ error }}</div>
+    </div>
+  </div>
 </div>

--- a/src/app/pages/registro/registro.component.css
+++ b/src/app/pages/registro/registro.component.css
@@ -1,10 +1,15 @@
 .registro-container {
-  max-width: 480px;
-  margin: 2rem auto;
+  width: 100%;
   padding: 1.5rem;
   background: #fff;
   border: 1px solid #ddd;
   border-radius: 8px;
+}
+
+@media (max-width: 575.98px) {
+  .registro-container {
+    padding: 1rem;
+  }
 }
 .form-group {
   margin-bottom: 1rem;

--- a/src/app/pages/registro/registro.component.html
+++ b/src/app/pages/registro/registro.component.html
@@ -1,5 +1,7 @@
-<div class="container mt-5" style="max-width: 500px;">
-  <h2 class="text-center text-pink mb-4">Registrarse</h2>
+<div class="container py-5">
+  <div class="row justify-content-center">
+    <div class="col-12 col-md-8 col-lg-6 registro-container">
+      <h2 class="text-center text-pink mb-4">Registrarse</h2>
 
   <form [formGroup]="registroForm" (ngSubmit)="registrar()" class="bg-white p-4 shadow rounded">
    
@@ -90,5 +92,7 @@
 
   <div class="text-center mt-3">
     <a routerLink="/login" class="text-decoration-none text-pink">¿Ya tienes cuenta? Iniciar sesión</a>
+  </div>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- use responsive breakpoints in `home` hero
- wrap login form in Bootstrap grid
- adjust login container padding for small screens
- wrap register, create-user and recovery forms in grid columns
- tweak form container styles for mobile

## Testing
- `CHROME_BIN=$(node -p "require('puppeteer').executablePath()") npm test -- --browsers=ChromeHeadless --watch=false`

------
https://chatgpt.com/codex/tasks/task_e_687a9cbdc16c83329295fdd596ea1f1c