### PR TITLE
Implement role-based authentication

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,7 +1,7 @@
 /**
  * @description Módulo principal que reúne componentes y servicios.
  */
-import { NgModule } from '@angular/core';
+import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common'; 
 import { FormsModule, ReactiveFormsModule } from '@angular/forms'; 
@@ -9,6 +9,7 @@ import { HttpClientModule } from '@angular/common/http';
 
 import { AppRoutingModule } from './app-routing.module';
 import { SharedModule } from './shared/shared.module';
+import { UserService } from './services/user.service';
 
 import { AppComponent } from './app.component';
 import { HomeComponent } from './pages/home/home.component';
@@ -47,7 +48,14 @@ import { ListaProductosComponent } from './pages/lista-productos/lista-productos
     AppRoutingModule,
     SharedModule
   ],
-  providers: [],
+  providers: [
+    {
+      provide: APP_INITIALIZER,
+      useFactory: (userSvc: UserService) => () => userSvc.init(),
+      deps: [UserService],
+      multi: true
+    }
+  ],
   bootstrap: [AppComponent]
 })
 /**

--- a/src/app/guards/admin.guard.spec.ts
+++ b/src/app/guards/admin.guard.spec.ts
@@ -1,15 +1,22 @@
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { AdminGuard } from './admin.guard';
+import { AuthService } from '../services/auth.service';
 
 describe('AdminGuard', () => {
   let guard: AdminGuard;
   let router: Router;
+  let authSpy: jasmine.SpyObj<AuthService>;
 
   beforeEach(() => {
+    authSpy = jasmine.createSpyObj('AuthService', ['getCurrent']);
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule]
+      imports: [RouterTestingModule, HttpClientTestingModule],
+      providers: [
+        { provide: AuthService, useValue: authSpy }
+      ]
     });
     guard = TestBed.inject(AdminGuard);
     router = TestBed.inject(Router);
@@ -17,18 +24,19 @@ describe('AdminGuard', () => {
   });
 
   it('should allow admin user', () => {
-    localStorage.setItem('usuario', JSON.stringify({ rol: 'admin' }));
+    authSpy.getCurrent.and.returnValue({ rol: 'admin', email: '', password: '' });
     expect(guard.canActivate()).toBeTrue();
   });
 
   it('should redirect normal user to /perfil', () => {
-    localStorage.setItem('usuario', JSON.stringify({ email: 'user@example.com' }));
+    authSpy.getCurrent.and.returnValue({ rol: 'usuario', email: 'user@example.com', password: '' });
     spyOn(router, 'navigate');
     expect(guard.canActivate()).toBeFalse();
     expect(router.navigate).toHaveBeenCalledWith(['/perfil']);
   });
 
   it('should redirect unauthenticated user to /login', () => {
+    authSpy.getCurrent.and.returnValue(null);
     spyOn(router, 'navigate');
     expect(guard.canActivate()).toBeFalse();
     expect(router.navigate).toHaveBeenCalledWith(['/login']);

--- a/src/app/guards/admin.guard.ts
+++ b/src/app/guards/admin.guard.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { CanActivate, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
 
 @Injectable({ providedIn: 'root' })
 /** Evita que usuarios no administradores accedan a rutas de administración. */
@@ -7,23 +8,18 @@ export class AdminGuard implements CanActivate {
   /**
    * @param router Inyectado para redirecciones si no es administrador
    */
-  constructor(private router: Router) {}
+  constructor(private router: Router, private auth: AuthService) {}
 
   /**
    * Verifica si hay un usuario administrador logueado
    * @returns `true` si tiene permisos de administrador
    */
   canActivate(): boolean {
-    const raw = localStorage.getItem('usuario');
-    if (!raw) {
-      this.router.navigate(['/login']);
-      return false;
-    }
-    const user = JSON.parse(raw);
-    if (user.rol === 'admin') {
+    const user = this.auth.getCurrent();
+    if (user && user.rol === 'admin') {
       return true;
     }
-    this.router.navigate(['/perfil']);
+    this.router.navigate([user ? '/perfil' : '/login']);
     return false;
   }
 }

--- a/src/app/guards/auth.guard.spec.ts
+++ b/src/app/guards/auth.guard.spec.ts
@@ -1,15 +1,20 @@
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { AuthGuard } from './auth.guard';
+import { AuthService } from '../services/auth.service';
 
 describe('AuthGuard', () => {
   let guard: AuthGuard;
   let router: Router;
+  let authSpy: jasmine.SpyObj<AuthService>;
 
   beforeEach(() => {
+    authSpy = jasmine.createSpyObj('AuthService', ['getCurrent']);
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule]
+      imports: [RouterTestingModule, HttpClientTestingModule],
+      providers: [ { provide: AuthService, useValue: authSpy } ]
     });
     guard = TestBed.inject(AuthGuard);
     router = TestBed.inject(Router);
@@ -17,11 +22,12 @@ describe('AuthGuard', () => {
   });
 
   it('should allow when user exists', () => {
-    localStorage.setItem('usuario', JSON.stringify({ email: 'user@example.com' }));
+    authSpy.getCurrent.and.returnValue({ email: 'user@example.com', password: '', rol: 'usuario' });
     expect(guard.canActivate()).toBeTrue();
   });
 
   it('should redirect to /login when no user', () => {
+    authSpy.getCurrent.and.returnValue(null);
     spyOn(router, 'navigate');
     expect(guard.canActivate()).toBeFalse();
     expect(router.navigate).toHaveBeenCalledWith(['/login']);

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { CanActivate, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
 
 @Injectable({ providedIn: 'root' })
 /** Protege rutas que requieren un usuario autenticado. */
@@ -7,15 +8,15 @@ export class AuthGuard implements CanActivate {
   /**
    * @param router Router usado para redirigir a login si no hay sesión
    */
-  constructor(private router: Router) {}
+  constructor(private router: Router, private auth: AuthService) {}
 
   /**
    * Comprueba si existe una sesión activa
    * @returns `true` cuando hay usuario autenticado
    */
   canActivate(): boolean {
-    const raw = localStorage.getItem('usuario');
-    if (raw) {
+    const user = this.auth.getCurrent();
+    if (user) {
       return true;
     }
     this.router.navigate(['/login']);

--- a/src/app/pages/login/login.component.spec.ts
+++ b/src/app/pages/login/login.component.spec.ts
@@ -3,18 +3,23 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { LoginComponent } from './login.component';
+import { AuthService } from '../../services/auth.service';
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
   let fixture: ComponentFixture<LoginComponent>;
   let router: Router;
+  let authSpy: jasmine.SpyObj<AuthService>;
 
   // Configura el entorno de pruebas
   beforeEach(async () => {
+    authSpy = jasmine.createSpyObj('AuthService', ['login', 'getCurrent']);
     await TestBed.configureTestingModule({
       declarations: [ LoginComponent ],
-      imports: [ ReactiveFormsModule, RouterTestingModule ]
+      imports: [ ReactiveFormsModule, RouterTestingModule, HttpClientTestingModule ],
+      providers: [ { provide: AuthService, useValue: authSpy } ]
     }).compileComponents();
   });
 
@@ -40,9 +45,8 @@ describe('LoginComponent', () => {
   // Admin válido redirige al panel
   it('debe navegar a /admin con credenciales admin@example.com/Admin#123', () => {
     spyOn(router, 'navigate');
-    localStorage.setItem('usuarios', JSON.stringify([
-      { nombre: 'admin', email: 'admin@example.com', password: 'Admin#123', rol: 'admin' }
-    ]));
+    authSpy.login.and.returnValue(true);
+    authSpy.getCurrent.and.returnValue({ email: 'admin@example.com', password: 'Admin#123', rol: 'admin' });
     component.loginForm.get('email')?.setValue('admin@example.com');
     component.loginForm.get('password')?.setValue('Admin#123');
     component.iniciarSesion();
@@ -52,9 +56,8 @@ describe('LoginComponent', () => {
   // Usuario normal redirige a su perfil
   it('debe navegar a /perfil con credenciales de usuario normal', () => {
     spyOn(router, 'navigate');
-    localStorage.setItem('usuarios', JSON.stringify([
-      { nombre: 'User', email: 'user@example.com', password: 'User#123' }
-    ]));
+    authSpy.login.and.returnValue(true);
+    authSpy.getCurrent.and.returnValue({ email: 'user@example.com', password: 'User#123', rol: 'usuario' });
     component.loginForm.get('email')?.setValue('user@example.com');
     component.loginForm.get('password')?.setValue('User#123');
     component.iniciarSesion();

--- a/src/app/pages/login/login.component.ts
+++ b/src/app/pages/login/login.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Title, Meta } from '@angular/platform-browser';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
+import { AuthService } from '../../services/auth.service';
 
 /**
  * @description Información de usuarios para el ejemplo de login.
@@ -47,7 +48,8 @@ export class LoginComponent implements OnInit {
     private fb: FormBuilder,
     private router: Router,
     private title: Title,
-    private meta: Meta
+    private meta: Meta,
+    private auth: AuthService
   ) {}
 
   /**
@@ -63,12 +65,6 @@ export class LoginComponent implements OnInit {
       content: 'Accede a tu cuenta de Piña Costa.'
     });
 
-    const seedAdmin: Usuario = { nombre: 'Admin', email: 'admin@example.com', password: 'Admin#123', rol: 'admin' };
-    const seedUser:  Usuario = { nombre: 'Usuario', email: 'user@example.com', password: 'User#123', rol: 'usuario' };
-    const usuarios: Usuario[] = JSON.parse(localStorage.getItem('usuarios') || '[]');
-    if (!usuarios.find(u => u.email === seedAdmin.email)) usuarios.unshift(seedAdmin);
-    if (!usuarios.find(u => u.email === seedUser.email))  usuarios.push(seedUser);
-    localStorage.setItem('usuarios', JSON.stringify(usuarios));
 
     this.loginForm = this.fb.group({
       email:    ['', [Validators.required, Validators.email]],
@@ -90,14 +86,16 @@ export class LoginComponent implements OnInit {
       return;
     }
     const { email, password } = this.loginForm.value;
-    const usuarios: Usuario[] = JSON.parse(localStorage.getItem('usuarios') || '[]');
-    const usuario = usuarios.find(u => u.email === email && u.password === password);
-    if (!usuario) {
+    const ok = this.auth.login(email, password);
+    if (!ok) {
       this.error = 'Correo o contraseña incorrectos';
       return;
     }
-    localStorage.setItem('usuario', JSON.stringify(usuario));
-    this.router.navigate([ usuario.rol === 'admin' ? '/admin' : '/perfil' ]);
+    const usuario = this.auth.getCurrent();
+    if (usuario) {
+      localStorage.setItem('usuario', JSON.stringify(usuario));
+      this.router.navigate([usuario.rol === 'admin' ? '/admin' : '/perfil']);
+    }
   }
 
   /**

--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { AuthService } from './auth.service';
 import { UserService, Usuario } from './user.service';
 
@@ -9,6 +10,7 @@ describe('AuthService', () => {
   beforeEach(() => {
     userSvcSpy = jasmine.createSpyObj('UserService', ['find']);
     TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
       providers: [
         AuthService,
         { provide: UserService, useValue: userSvcSpy }
@@ -27,27 +29,27 @@ describe('AuthService', () => {
   });
 
   it('should login with valid credentials', () => {
-    const user: Usuario = { username: 'test', password: '123', role: 'usuario' };
+    const user: Usuario = { email: 'test@example.com', password: '123', rol: 'usuario' } as any;
     userSvcSpy.find.and.returnValue(user);
-    const result = service.login('test', '123');
+    const result = service.login('test@example.com', '123');
     expect(result).toBeTrue();
     expect(service.getCurrent()).toEqual(user);
     expect(localStorage.getItem('currentUser')).toBe(JSON.stringify(user));
   });
 
   it('should reject invalid credentials', () => {
-    const user: Usuario = { username: 'test', password: '123', role: 'usuario' };
+    const user: Usuario = { email: 'test@example.com', password: '123', rol: 'usuario' } as any;
     userSvcSpy.find.and.returnValue(user);
-    const result = service.login('test', 'wrong');
+    const result = service.login('test@example.com', 'wrong');
     expect(result).toBeFalse();
     expect(service.getCurrent()).toBeNull();
     expect(localStorage.getItem('currentUser')).toBeNull();
   });
 
   it('should logout and clear session', () => {
-    const user: Usuario = { username: 'test', password: '123', role: 'usuario' };
+    const user: Usuario = { email: 'test@example.com', password: '123', rol: 'usuario' } as any;
     userSvcSpy.find.and.returnValue(user);
-    service.login('test', '123');
+    service.login('test@example.com', '123');
     service.logout();
     expect(service.getCurrent()).toBeNull();
     expect(localStorage.getItem('currentUser')).toBeNull();

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -27,12 +27,12 @@ export class AuthService {
   /**
    * @description Inicia sesión si las credenciales son válidas. Persiste la sesión en localStorage.
    * 
-   * @param username Nombre de usuario.
+   * @param email Correo electrónico del usuario.
    * @param password Contraseña del usuario.
    * @returns `true` si las credenciales coinciden, `false` en caso contrario.
    */
-  login(username: string, password: string): boolean {
-    const u = this.userSvc.find(username);
+  login(email: string, password: string): boolean {
+    const u = this.userSvc.find(email);
     if (u && u.password === password) {
       this.current$.next(u);
       localStorage.setItem('currentUser', JSON.stringify(u));

--- a/src/app/services/user.service.spec.ts
+++ b/src/app/services/user.service.spec.ts
@@ -1,5 +1,6 @@
 // Pruebas del servicio de usuarios.
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { UserService } from './user.service';
 
@@ -8,7 +9,9 @@ describe('UserService', () => {
 
   // Se ejecuta antes de cada prueba
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
     service = TestBed.inject(UserService);
   });
 

--- a/src/assets/data/usuarios.json
+++ b/src/assets/data/usuarios.json
@@ -1,0 +1,14 @@
+[
+  {
+    "email": "admin@example.com",
+    "password": "Admin#123",
+    "nombre": "Admin",
+    "rol": "admin"
+  },
+  {
+    "email": "user@example.com",
+    "password": "User#123",
+    "nombre": "Usuario",
+    "rol": "usuario"
+  }
+]


### PR DESCRIPTION
## Summary
- load user data from JSON on startup
- use AuthService in login to manage sessions
- guard routes with AuthService
- update unit tests for new AuthService logic
- provide sample users JSON

## Testing
- `npm test --silent -- --browsers=ChromeHeadless --watch=false`
- `npx ng lint`

------
https://chatgpt.com/codex/tasks/task_e_687aa76511348332a2ecc6305446fab0